### PR TITLE
Webview take screenshot with secondary thread

### DIFF
--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -10,6 +10,7 @@ import android.hardware.display.DisplayManager;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Message;
+import android.os.Looper;
 import android.view.View;
 import android.webkit.WebChromeClient;
 import android.webkit.WebResourceRequest;
@@ -31,6 +32,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.io.ByteArrayOutputStream;
+import java.lang.Thread;
 
 public class FlutterWebView implements PlatformView, MethodCallHandler {
   private static final String JS_CHANNEL_NAMES_FIELD = "javascriptChannelNames";
@@ -403,6 +405,7 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
   }
 
   private void takeScreenshot(Result result){
+    final Result fResult = result
     View view = getView();
 
     float scale = view.getContext().getResources().getDisplayMetrics().density;
@@ -428,13 +431,24 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
     int rectWidth = b.getWidth();
     int rectHeight = measuredHeight;
 
-    Bitmap resized = Bitmap.createBitmap(b, rectX, rectY, rectWidth, rectHeight);
+    final Bitmap resized = Bitmap.createBitmap(b, rectX, rectY, rectWidth, rectHeight);
 
-    ByteArrayOutputStream stream = new ByteArrayOutputStream();
-    resized.compress(Bitmap.CompressFormat.PNG, 100, stream);
-    byte[] imageByteArray = stream.toByteArray();
-    
-    result.success(imageByteArray);
+    new Thread(new Runnable() {
+    @Override
+    public void run() {
+      ByteArrayOutputStream stream = new ByteArrayOutputStream();
+      resized.compress(Bitmap.CompressFormat.PNG, 100, stream);
+      final byte[] imageByteArray = stream.toByteArray();
+
+      new Handler(Looper.getMainLooper()).post(new Runnable() {
+              @Override
+              public void run() {
+                 fResult.success(imageByteArray);
+              }
+            });
+    }
+   }).start();
+
   }
 
   private void applySettings(Map<String, Object> settings) {

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -405,7 +405,7 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
   }
 
   private void takeScreenshot(Result result){
-    final Result fResult = result
+    final Result fResult = result;
     View view = getView();
 
     float scale = view.getContext().getResources().getDisplayMetrics().density;
@@ -438,7 +438,7 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
     @Override
     public void run() {
       ByteArrayOutputStream stream = new ByteArrayOutputStream();
-      resized.compress(Bitmap.CompressFormat.PNG, 100, stream);
+      resized.compress(Bitmap.CompressFormat.PNG, 80, stream);
       final byte[] imageByteArray = stream.toByteArray();
 
       // make sure to return the result in the main thread

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -433,6 +433,7 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
 
     final Bitmap resized = Bitmap.createBitmap(b, rectX, rectY, rectWidth, rectHeight);
 
+    // run the compress function in a secondary thread
     new Thread(new Runnable() {
     @Override
     public void run() {
@@ -440,6 +441,7 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
       resized.compress(Bitmap.CompressFormat.PNG, 100, stream);
       final byte[] imageByteArray = stream.toByteArray();
 
+      // make sure to return the result in the main thread
       new Handler(Looper.getMainLooper()).post(new Runnable() {
               @Override
               public void run() {


### PR DESCRIPTION
## Description
Implements secondary thread for compress function when taking screenshot of the webview

## Pre-launch Checklist

- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
