### PR TITLE
TB-2041 Fix for cached webview using cached platform callbacks

### DIFF
--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -479,14 +479,10 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
           if (mode != null) updateJsMode(mode);
           break;
         case "hasNavigationDelegate":
-          if (shouldLoad) {
-            final boolean hasNavigationDelegate = (boolean) settings.get(key);
-
-            final WebViewClient webViewClient =
-                    flutterWebViewClient.createWebViewClient(hasNavigationDelegate, hostsToBlock);
-
-            webView.setWebViewClient(webViewClient);
-          }
+          final boolean hasNavigationDelegate = (boolean) settings.get(key);
+          final WebViewClient webViewClient =
+                  flutterWebViewClient.createWebViewClient(hasNavigationDelegate, hostsToBlock);
+          webView.setWebViewClient(webViewClient);
           break;
         case "debuggingEnabled":
           final boolean debuggingEnabled = (boolean) settings.get(key);


### PR DESCRIPTION
[TB-2041](https://xainag.atlassian.net/browse/TB-2041)

This fixes an isssue with `onPageStarted`, `onPageFinished` callbacks being cached by the WebView and calling old instances of `widget` (diposed widget instead of newly created, current one)