### PR TITLE
TB-2190 Fix webview screenshot leak

### DIFF
--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -6,6 +6,7 @@ package io.flutter.plugins.webviewflutter;
 
 import android.annotation.TargetApi;
 import android.content.Context;
+import android.graphics.Color;
 import android.hardware.display.DisplayManager;
 import android.os.Build;
 import android.os.Handler;
@@ -136,7 +137,10 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
     if (shouldLoad) {
       // allow app cache
       webView.getSettings().setAppCacheEnabled(true);
-      
+
+      // use transparent bg
+      webView.setBackgroundColor(Color.TRANSPARENT);
+
       // Allow local storage.
       webView.getSettings().setDomStorageEnabled(true);
       webView.getSettings().setJavaScriptCanOpenWindowsAutomatically(true);

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -465,28 +465,18 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
       new Thread(new Runnable() {
         @Override
         public void run() {
-          if (b != null) {
-            ByteArrayOutputStream stream = new ByteArrayOutputStream();
-            b.compress(Bitmap.CompressFormat.PNG, 80, stream);
-            final byte[] imageByteArray = stream.toByteArray();
-            // make sure to return the result in the main thread
-            new Handler(Looper.getMainLooper()).post(new Runnable() {
-              @Override
-              public void run() {
-                fResult.success(imageByteArray);
-              }
-            });
+          ByteArrayOutputStream stream = new ByteArrayOutputStream();
+          b.compress(Bitmap.CompressFormat.PNG, 80, stream);
+          final byte[] imageByteArray = stream.toByteArray();
+          // make sure to return the result in the main thread
+          new Handler(Looper.getMainLooper()).post(new Runnable() {
+            @Override
+            public void run() {
+              fResult.success(imageByteArray);
+            }
+          });
 
-            b.recycle();
-          } else {
-            new Handler(Looper.getMainLooper()).post(new Runnable() {
-              @Override
-              public void run() {
-                // treat an empty bitmap as a successful empty screenshot result
-                fResult.success(new byte[0]);
-              }
-            });
-          }
+          b.recycle();
         }
       }).start();
     }

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -439,40 +439,17 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
 
   private void takeScreenshot(Result result){
     final Result fResult = result;
-    View view = getView();
-
-    float scale = view.getContext().getResources().getDisplayMetrics().density;
-    int height = (int) (webView.getContentHeight() * scale);
-
-    Bitmap b = Bitmap.createBitmap(view.getWidth(),
-                  height, Bitmap.Config.ARGB_8888);
-    Canvas c = new Canvas(b);
-    view.draw(c);
-    int scrollY = webView.getScrollY();
-    int measuredHeight = webView.getMeasuredHeight();
-    int bitmapHeight = b.getHeight();
-
-    int scrollOffset = (scrollY + measuredHeight > bitmapHeight)
-                  ? (bitmapHeight - measuredHeight) : scrollY;
-    
-     if (scrollOffset < 0) {
-          scrollOffset = 0;
-    }
-
-    int rectX = 0;
-    int rectY = scrollOffset;
-    int rectWidth = b.getWidth();
-    int rectHeight = measuredHeight;
-
-    final Bitmap resized = Bitmap.createBitmap(b, rectX, rectY, rectWidth, rectHeight);
 
     // run the compress function in a secondary thread
     new Thread(new Runnable() {
     @Override
     public void run() {
+      webView.setDrawingCacheEnabled(true);
+      final Bitmap b = webView.getDrawingCache(false);
       ByteArrayOutputStream stream = new ByteArrayOutputStream();
-      resized.compress(Bitmap.CompressFormat.PNG, 80, stream);
+      b.compress(Bitmap.CompressFormat.PNG, 80, stream);
       final byte[] imageByteArray = stream.toByteArray();
+      webView.setDrawingCacheEnabled(false);
 
       // make sure to return the result in the main thread
       new Handler(Looper.getMainLooper()).post(new Runnable() {

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -446,18 +446,29 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
     public void run() {
       webView.setDrawingCacheEnabled(true);
       final Bitmap b = webView.getDrawingCache(false);
-      ByteArrayOutputStream stream = new ByteArrayOutputStream();
-      b.compress(Bitmap.CompressFormat.PNG, 80, stream);
-      final byte[] imageByteArray = stream.toByteArray();
-      webView.setDrawingCacheEnabled(false);
 
-      // make sure to return the result in the main thread
-      new Handler(Looper.getMainLooper()).post(new Runnable() {
-              @Override
-              public void run() {
-                 fResult.success(imageByteArray);
-              }
-            });
+      if (b != null) {
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        b.compress(Bitmap.CompressFormat.PNG, 80, stream);
+        final byte[] imageByteArray = stream.toByteArray();
+        // make sure to return the result in the main thread
+        new Handler(Looper.getMainLooper()).post(new Runnable() {
+          @Override
+          public void run() {
+            fResult.success(imageByteArray);
+          }
+        });
+      } else {
+        new Handler(Looper.getMainLooper()).post(new Runnable() {
+          @Override
+          public void run() {
+            // treat an empty bitmap as a successful empty screenshot result
+            fResult.success(new byte[0]);
+          }
+        });
+      }
+
+      webView.setDrawingCacheEnabled(false);
     }
    }).start();
 

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -134,6 +134,9 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
     platformThreadHandler = new Handler(context.getMainLooper());
 
     if (shouldLoad) {
+      // allow app cache
+      webView.getSettings().setAppCacheEnabled(true);
+      
       // Allow local storage.
       webView.getSettings().setDomStorageEnabled(true);
       webView.getSettings().setJavaScriptCanOpenWindowsAutomatically(true);

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -447,7 +447,6 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
     final Bitmap cacheBitmap = webView.getDrawingCache();
     final Bitmap b = (cacheBitmap != null) ? cacheBitmap.copy(Bitmap.Config.RGB_565, false) : null;
 
-    webView.destroyDrawingCache();
     webView.setDrawingCacheEnabled(isDrawingCacheEnabled);
 
     // run the compress function in a secondary thread


### PR DESCRIPTION
Uses the cache for smaller bitmaps
after done, turns off the cache again, so that the cache can recycle.

The old screenshot solution could crash the app if the webview was too high, and also didn't recycle old Bitmaps