### PR TITLE
[TB-2518] Fire onPageFinished event when WebView was cached

### DIFF
--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -114,6 +114,10 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
       webView = webViewManager.webViewForId(tabId);
     }
 
+    methodChannel = new MethodChannel(messenger, "plugins.flutter.io/webview_" + id);
+    methodChannel.setMethodCallHandler(this);
+    flutterWebViewClient = new FlutterWebViewClient(methodChannel);
+
     if (webView == null) {
         Boolean usesHybridComposition = (Boolean) params.get("usesHybridComposition");
         webView =
@@ -127,6 +131,10 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
         String tabId = (String) params.get("tabId");
         webViewManager.cacheWebView(webView, tabId);
       }
+    } else if (params.containsKey("initialUrl")) {
+        // WebView was cached so report the onPageFinished event
+        String url = (String) params.get("initialUrl");
+        flutterWebViewClient.onPageFinished();
     }
 
     displayListenerProxy.onPostWebViewInitialization(displayManager);
@@ -143,8 +151,7 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
       webView.setWebChromeClient(new FlutterWebChromeClient());
     }
 
-    methodChannel = new MethodChannel(messenger, "plugins.flutter.io/webview_" + id);
-    methodChannel.setMethodCallHandler(this);
+    
 
     if (params.containsKey("blockingRules") && !ContentBlocker.INSTANCE.isReady()) {
       Map<String, Map<String, Object>> rules = (Map<String, Map<String, Object>>) params.get("blockingRules");
@@ -155,7 +162,6 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
       ContentBlocker.INSTANCE.setupContentBlocking(rules, whiteListing);
     }
 
-    flutterWebViewClient = new FlutterWebViewClient(methodChannel);
     Map<String, Object> settings = (Map<String, Object>) params.get("settings");
     if (settings != null) applySettings(settings);
 

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -134,7 +134,7 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
     } else if (params.containsKey("initialUrl")) {
         // WebView was cached so report the onPageFinished event
         String url = (String) params.get("initialUrl");
-        flutterWebViewClient.onPageFinished();
+        flutterWebViewClient.onPageFinished(url);
     }
 
     displayListenerProxy.onPostWebViewInitialization(displayManager);

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
@@ -133,14 +133,14 @@ class FlutterWebViewClient {
         return true;
     }
 
-    private void onPageStarted(WebView view, String url) {
+    void onPageStarted(String url) {
         currentHostUrl = url;
         Map<String, Object> args = new HashMap<>();
         args.put("url", url);
         methodChannel.invokeMethod("onPageStarted", args);
     }
 
-    private void onPageFinished(WebView view, String url) {
+    void onPageFinished(String url) {
         Map<String, Object> args = new HashMap<>();
         args.put("url", url);
         methodChannel.invokeMethod("onPageFinished", args);
@@ -218,12 +218,12 @@ class FlutterWebViewClient {
 
             @Override
             public void onPageStarted(WebView view, String url, Bitmap favicon) {
-                FlutterWebViewClient.this.onPageStarted(view, url);
+                FlutterWebViewClient.this.onPageStarted(url);
             }
 
             @Override
             public void onPageFinished(WebView view, String url) {
-                FlutterWebViewClient.this.onPageFinished(view, url);
+                FlutterWebViewClient.this.onPageFinished(url);
             }
 
             @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
@@ -271,12 +271,12 @@ class FlutterWebViewClient {
 
             @Override
             public void onPageStarted(WebView view, String url, Bitmap favicon) {
-                FlutterWebViewClient.this.onPageStarted(view, url);
+                FlutterWebViewClient.this.onPageStarted(url);
             }
 
             @Override
             public void onPageFinished(WebView view, String url) {
-                FlutterWebViewClient.this.onPageFinished(view, url);
+                FlutterWebViewClient.this.onPageFinished(url);
             }
 
             @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
@@ -133,14 +133,14 @@ class FlutterWebViewClient {
         return true;
     }
 
-    void onPageStarted(String url) {
+    public void onPageStarted(String url) {
         currentHostUrl = url;
         Map<String, Object> args = new HashMap<>();
         args.put("url", url);
         methodChannel.invokeMethod("onPageStarted", args);
     }
 
-    void onPageFinished(String url) {
+    public void onPageFinished(String url) {
         Map<String, Object> args = new HashMap<>();
         args.put("url", url);
         methodChannel.invokeMethod("onPageFinished", args);

--- a/packages/webview_flutter/ios/Classes/FLTWKNavigationDelegate.h
+++ b/packages/webview_flutter/ios/Classes/FLTWKNavigationDelegate.h
@@ -11,6 +11,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithChannel:(FlutterMethodChannel*)channel;
 
+- (void)onPageStartedWithUrl:(NSString * _Nonnull)urlString;
+- (void)onPageFinishedWithUrl:(NSString * _Nonnull)urlString;
+
 /**
  * Whether to delegate navigation decisions over the method channel.
  */

--- a/packages/webview_flutter/ios/Classes/FLTWKNavigationDelegate.m
+++ b/packages/webview_flutter/ios/Classes/FLTWKNavigationDelegate.m
@@ -16,10 +16,18 @@
   return self;
 }
 
+- (void)onPageStartedWithUrl:(NSString * _Nonnull)urlString {
+    [_methodChannel invokeMethod:@"onPageStarted" arguments:@{@"url" : urlString}];
+}
+
+- (void)onPageFinishedWithUrl:(NSString * _Nonnull)urlString {
+    [_methodChannel invokeMethod:@"onPageFinished" arguments:@{@"url" : urlString}];
+}
+
 #pragma mark - WKNavigationDelegate conformance
 
 - (void)webView:(WKWebView *)webView didStartProvisionalNavigation:(WKNavigation *)navigation {
-  [_methodChannel invokeMethod:@"onPageStarted" arguments:@{@"url" : webView.URL.absoluteString}];
+    [self onPageStartedWithUrl:webView.URL.absoluteString];
 }
 
 - (void)webView:(WKWebView *)webView
@@ -63,7 +71,7 @@
 }
 
 - (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation {
-  [_methodChannel invokeMethod:@"onPageFinished" arguments:@{@"url" : webView.URL.absoluteString}];
+    [self onPageFinishedWithUrl:webView.URL.absoluteString];
 }
 
 + (id)errorCodeToString:(NSUInteger)code {

--- a/packages/webview_flutter/ios/Classes/FlutterWebView.m
+++ b/packages/webview_flutter/ios/Classes/FlutterWebView.m
@@ -116,6 +116,8 @@
         _webView = [webViewManager webViewForId:tabId];
     }
     
+    _navigationDelegate = [[FLTWKNavigationDelegate alloc] initWithChannel:_channel];
+
     BOOL shouldLoad = NO;
     if (!_webView) {
         _webView = [[FLTWKWebView alloc] initWithFrame:frame configuration:configuration];
@@ -125,9 +127,12 @@
             NSString *tabId = args[@"tabId"];
             [webViewManager cacheWebView:_webView forId:tabId];
         }
+    } else if (args[@"initialUrl"]) {
+        // WebView was cached so report the onPageFinished event
+        NSString* initialUrl = args[@"initialUrl"];
+        [_navigationDelegate onPageFinishedWithUrl:initialUrl];
     }
       
-    _navigationDelegate = [[FLTWKNavigationDelegate alloc] initWithChannel:_channel];
     _webView.UIDelegate = self;
     _webView.navigationDelegate = _navigationDelegate;
     __weak __typeof__(self) weakSelf = self;


### PR DESCRIPTION
Jira ticket: [TB-2518](https://xainag.atlassian.net/browse/TB-2518)

When we use a cached WebView, the callbacks are not fired thus progress bar will never be full. This PR solves this by calling `onPageFinished` after cached version is used.